### PR TITLE
Bump to latest asahi / asahi-dev revs

### DIFF
--- a/sys-boot/u-boot/u-boot-2022.07_rc100.ebuild
+++ b/sys-boot/u-boot/u-boot-2022.07_rc100.ebuild
@@ -1,0 +1,70 @@
+# Copyright 2022 James Calligeros <jcalligeros99@gmail.com>
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="7"
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit eutils autotools git-r3 distutils-r1
+
+DESCRIPTION="Asahi Linux fork of Das U-Boot"
+HOMEPAGE="https://asahilinux.org/"
+LICENSE="GPL-2"
+KEYWORDS="~arm64"
+SLOT="0"
+EGIT_REPO_URI="https://github.com/AsahiLinux/u-boot.git"
+EGIT_CLONE_TYPE="shallow"
+
+BDEPEND="
+    app-arch/cpio
+	dev-lang/perl
+	sys-devel/bc
+	sys-devel/bison
+	sys-devel/flex
+	sys-devel/make
+	>=sys-libs/ncurses-5.2
+	virtual/libelf
+	virtual/pkgconfig
+    sys-apps/dtc
+    dev-vcs/git"
+
+RDEPEND="${BDEPEND}"
+
+# We need to do some extra stuff to get a non-tagged git repo
+if [[ ${PV} == "9999" ]]; then
+	EGIT_BRANCH="asahi"
+else
+	EGIT_COMMIT="asahi-v2022.07-1"
+fi
+
+src_unpack() {
+    einfo "Using GitHub sources, cloning from AsahiLinux/u-boot..."
+    git-r3_src_unpack
+}
+
+src_configure() {
+    emake apple_m1_defconfig || die "failed to apply defconfig!"
+}
+
+src_compile() {
+    cd "${S}" || die
+    emake || die "emake failed"
+}
+
+src_install() {
+	dodir /usr/lib/asahi-boot
+	cp ${S}/u-boot-nodtb.bin "${ED%/}"/usr/lib/asahi-boot/u-boot-nodtb.bin || die
+}
+
+
+pkg_postinst() {
+	elog "U-Boot has been installed to /usr/lib/asahi-boot/u-boot-nodtb.bin."
+	elog "You must run update-m1n1 for the new version to be installed"
+	elog "in the ESP."
+	elog "Please see the Asahi Linux Wiki for more information."
+}
+
+pkg_postrm() {
+	elog "U-Boot has been removed from /usr/lib/asahi-boot/ but has not"
+	elog "been removed from the ESP. You need to do this manually, though"
+	elog "you really shouldn't."
+}

--- a/sys-kernel/asahi-sources/asahi-sources-5.19.0_p1.ebuild
+++ b/sys-kernel/asahi-sources/asahi-sources-5.19.0_p1.ebuild
@@ -1,0 +1,73 @@
+# Copyright 2022 James Calligeros <jcalligeros99@gmail.com>
+# Distributed under the terms of the GNU General Public License v2
+
+# TODO: Migrate to ebuild based on Gentoo kernel eclass
+
+EAPI="7"
+ETYPE="sources"
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit eutils autotools
+
+DESCRIPTION="Asahi Linux kernel sources"
+HOMEPAGE="https://asahilinux.org/"
+LICENSE="GPL-2"
+IUSE="symlink"
+SLOT="0"
+KEYWORDS="~arm64"
+
+# We need to do some extra stuff to get a non-tagged git repo
+inherit git-r3 distutils-r1
+EGIT_REPO_URI="https://github.com/AsahiLinux/linux.git"
+EGIT_CLONE_TYPE="shallow" # --depth=1
+EGIT_BRANCH="asahi"
+SRC_URI=""
+BDEPEND="${BDEPEND}
+	dev-vcs/git"
+
+if [[ ${PV} == "9999" ]]; then
+	EGIT_COMMIT=""
+else
+	EGIT_COMMIT="asahi-5.19-1"
+fi
+
+RDEPEND="
+	app-arch/cpio
+	dev-lang/perl
+	sys-devel/bc
+	sys-devel/bison
+	sys-devel/flex
+	sys-devel/make
+	>=sys-libs/ncurses-5.2
+	sys-apps/dtc
+	virtual/libelf
+	virtual/pkgconfig"
+
+
+src_unpack() {
+	einfo "Using GitHub sources, cloning from AsahiLinux/linux..."
+	git-r3_src_unpack
+
+}
+
+src_compile() {
+	cd "${S}" || die
+}
+
+src_install() {
+	dodir /usr/src
+	mv ${S} "${ED%/}"/usr/src || die
+	use symlink && dosym /usr/src/${P} /usr/src/linux
+}
+
+
+pkg_postinst() {
+	elog "From here, follow the standard Gentoo Handbook instructions for"
+	elog "building a kernel."
+	elog " "
+	elog "For proper firmware support, see the Asahi Linux wiki."
+}
+
+pkg_postrm() {
+	elog "Follow the standard kernel removal/upgrade procedure"
+}

--- a/sys-kernel/asahi-sources/asahi-sources-5.19.0_rc7_p2.ebuild
+++ b/sys-kernel/asahi-sources/asahi-sources-5.19.0_rc7_p2.ebuild
@@ -28,7 +28,7 @@ BDEPEND="${BDEPEND}
 if [[ ${PV} == "9999" ]]; then
 	EGIT_COMMIT=""
 else
-	EGIT_COMMIT="asahi-5.19-rc7-1"
+	EGIT_COMMIT="asahi-5.19-rc7-2"
 fi
 
 RDEPEND="


### PR DESCRIPTION
Stable asahi-sources is bumped to asahi-5.19-rc7-2 for a single line dts fix for the M1 Macbook Air

Add `~arm64` ebuilds with M2 Macbook keyboard support in u-boot,
 - asahi-sources asahi-5.19-1
 - u-boot asahi-v2022.07-1