### PR TITLE
Add sys-firmware/asahi-firmware

### DIFF
--- a/sys-firmware/asahi-firmware/asahi-firmware-0.4.1.ebuild
+++ b/sys-firmware/asahi-firmware/asahi-firmware-0.4.1.ebuild
@@ -1,0 +1,46 @@
+# Copyright 2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{8..10} )
+
+inherit distutils-r1
+
+_name=asahi-installer
+
+DESCRIPTION="Asahi FW extraction script"
+HOMEPAGE="https://asahilinux.org"
+SRC_URI="https://github.com/AsahiLinux/${_name}/archive/refs/tags/v${PV}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="arm64"
+
+DEPEND=""
+RDEPEND="${DEPEND}"
+BDEPEND=""
+
+S="${WORKDIR}/${_name}-${PV}"
+
+src_install() {
+	distutils-r1_src_install
+
+	dosbin ${FILESDIR}/asahi-fwextract
+	dosbin ${FILESDIR}/update-vendor-firmware
+
+	# install for now a simple rc script into /etc/local.d
+	exeinto /etc/local.d/
+	doexe ${FILESDIR}/asahi-firmware.start
+}
+
+pkg_postinst() {
+	elog "Asahi vendor firmware update script"
+	elog "Please run 'asahi-fwextract' after each update of this package."
+
+	if [ -e ${ROOT}/bin/update-vendor-fw -o -e ${ROOT}/etc/local.d/apple-firmware.start ]; then
+		ewarn "please remober to remove '/bin/update-vendor-fw' and"
+		ewarn "'/etc/local.d/apple-firmware.start'"
+	fi
+}

--- a/sys-firmware/asahi-firmware/files/asahi-firmware.start
+++ b/sys-firmware/asahi-firmware/files/asahi-firmware.start
@@ -1,0 +1,9 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+if [ -e /etc/local.d/apple-firmware.start ]; then
+    return 0
+fi
+
+# Check for updates to Apple Silicon firmware at boot
+exec /usr/sbin/update-vendor-firmware

--- a/sys-firmware/asahi-firmware/files/asahi-fwextract
+++ b/sys-firmware/asahi-firmware/files/asahi-fwextract
@@ -1,0 +1,17 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -e
+
+if [ ! -f /boot/efi/asahi/all_firmware.tar.gz ]; then
+    printf '==> No /boot/efi/asahi/all_firmware.tar.gz, skipping firmware extraction'
+    return 0
+fi
+
+printf '==> Upgrading vendor firmware package...\n'
+python -m asahi_firmware.update /boot/efi/asahi /boot/efi/vendorfw/firmware.tar.new /boot/efi/vendorfw/manifest.txt.new
+mv -f /boot/efi/vendorfw/manifest.txt{.new,}
+mv -f /boot/efi/vendorfw/firmware.tar{.new,}
+printf '    Firmware upgraded\n'
+
+/usr/sbin/update-vendor-firmware

--- a/sys-firmware/asahi-firmware/files/update-vendor-firmware
+++ b/sys-firmware/asahi-firmware/files/update-vendor-firmware
@@ -1,0 +1,49 @@
+#!/bin/sh
+# SPDX-License-Identifier: MIT
+
+set -e
+
+VENDORFW=/boot/efi/vendorfw/
+TARGET=/lib/firmware/
+TARGET_MANIFEST=".vendorfw.manifest"
+
+[ -e /etc/default/update-vendor-firmware ] && source /etc/default/update-vendor-firmware
+
+if [ ! -e "$VENDORFW" ]; then
+    echo "No vendor firmware available"
+    exit 0
+fi
+
+if [ ! -e "$VENDORFW/manifest.txt" ]; then
+    echo "$VENDORFW/manifest.txt not found"
+    exit 1
+fi
+
+if [ ! -e "$VENDORFW/firmware.tar" ]; then
+    echo "$VENDORFW/firmware.tar not found"
+    exit 1
+fi
+
+cd "$TARGET"
+
+[ -e "$TARGET_MANIFEST" ] && \
+    cmp -s "$TARGET_MANIFEST" "$VENDORFW/manifest.txt" && exit 0
+
+echo "Extracting updated vendor firmware..."
+tar xf "$VENDORFW/firmware.tar"
+
+if [ -e "$TARGET_MANIFEST" ]; then
+    echo "Cleaning up obsolete firmware..."
+    comm \
+        <(sort "$VENDORFW/manifest.txt") \
+        <(sort "$TARGET_MANIFEST") -13 | \
+        while read type name rest; do
+            rm -v "$name" || true
+            dir="$(dirname "$name")"
+            rmdir "$dir" 2>/dev/null || true
+        done
+fi
+
+cp "$VENDORFW/manifest.txt" "$TARGET_MANIFEST"
+
+echo "Done"


### PR DESCRIPTION
Combination of asahi-installer's firmware extraction methods and the
vendor firmware update script from asahi-scripts.
Scripts are currently kept in $FILESDIR but should be versioned
somewhere separate.
rc.local script should be replaced by OpenRC/systemd script/service
which runs before udev.

Signed-off-by: Janne Grunau <j@jannau.net>