### PR TITLE
fix for the m1n1-1.1.5-r2 ebuild due to moving asahi-scripts

### DIFF
--- a/sys-boot/m1n1/m1n1-1.1.5-r2.ebuild
+++ b/sys-boot/m1n1/m1n1-1.1.5-r2.ebuild
@@ -20,8 +20,8 @@ BDEPEND="
 RDEPEND="
     sys-boot/u-boot
     sys-kernel/asahi-sources
-    app-admin/asahi-scripts"
-
+    sys-app/asahi-scripts"
+    
 inherit distutils-r1
 
 SRC_URI="https://github.com/AsahiLinux/m1n1/archive/refs/tags/v${PV}.tar.gz -> ${PN}-${PV}.tar.gz"


### PR DESCRIPTION
You moved asahi-scripts to sys-app but the ebuild still want's to use app-admin :)