### PR TITLE
update kernel config to linux-asahi-6.6

### DIFF
--- a/sys-apps/asahi-scripts/asahi-scripts-20231219.1.ebuild
+++ b/sys-apps/asahi-scripts/asahi-scripts-20231219.1.ebuild
@@ -10,7 +10,8 @@ SLOT="0"
 KEYWORDS="arm64"
 
 PATCHES=("${FILESDIR}/makefile.patch"
-	 "${FILESDIR}/update-m1n1-dtbs.patch")
+	 "${FILESDIR}/update-m1n1-dtbs.patch"
+	 "${FILESDIR}/dracut.patch")
 
 BDEPEND="
 	dev-build/make"

--- a/sys-apps/asahi-scripts/files/dracut.patch
+++ b/sys-apps/asahi-scripts/files/dracut.patch
@@ -1,0 +1,66 @@
+diff --git a/dracut/dracut.conf.d/10-asahi.conf b/dracut/dracut.conf.d/10-asahi.conf
+index 0e57dd8..887d659 100644
+--- a/dracut/dracut.conf.d/10-asahi.conf
++++ b/dracut/dracut.conf.d/10-asahi.conf
+@@ -1,28 +1,10 @@
+ # Modules necessary for using Linux on Apple Silicon Macs
+ 
+-# For NVMe & SMC
+-add_drivers+=" apple-mailbox "
+-
+-# For NVMe
+-add_drivers+=" nvme_apple "
+-
+-# For USB and HID
+-add_drivers+=" pinctrl-apple-gpio "
+-
+-# SMC core
+-add_drivers+=" macsmc macsmc-rtkit "
+-
+ # For USB
+-add_drivers+=" i2c-apple tps6598x apple-dart dwc3 dwc3-of-simple nvmem-apple-efuses phy-apple-atc xhci-plat-hcd xhci-pci pcie-apple gpio_macsmc "
+-
+-# For HID
+-add_drivers+=" spi-apple spi-hid-apple spi-hid-apple-of "
+-
+-# For RTC
+-add_drivers+=" rtc-macsmc simple-mfd-spmi spmi-apple-controller nvmem_spmi_mfd "
++add_drivers+=" dwc3-of-simple phy-apple-atc xhci-plat-hcd xhci-pci "
+ 
+ # For MTP HID
+-add_drivers+=" apple-dockchannel dockchannel-hid apple-rtkit-helper "
++add_drivers+=" dockchannel-hid "
+ 
+ # dwc3 instantiates xHCI asynchronously. To make things like init=/bin/sh work where udev is no longer running, force load this one.
+ force_drivers+=" xhci-plat-hcd "
+diff --git a/dracut/modules.d/99asahi-firmware/module-setup.sh b/dracut/modules.d/99asahi-firmware/module-setup.sh
+index 9018db5..b3abe02 100755
+--- a/dracut/modules.d/99asahi-firmware/module-setup.sh
++++ b/dracut/modules.d/99asahi-firmware/module-setup.sh
+@@ -20,7 +20,10 @@ depends() {
+ 
+ # called by dracut
+ installkernel() {
+-    instmods apple-mailbox nvme-apple vfat
++    # we now build this code in-kernel, not as modules...
++    # ...so we comment out the next line
++    # instmods apple-mailbox nvme-apple vfat
++    echo "instmods in installkernel() skipped"
+ }
+ 
+ # called by dracut
+diff --git a/initcpio/hooks/asahi b/initcpio/hooks/asahi
+index 50e017b..e985acd 100644
+--- a/initcpio/hooks/asahi
++++ b/initcpio/hooks/asahi
+@@ -13,8 +13,8 @@ run_earlyhook() {
+     fi
+ 
+     msg ":: Asahi: Triggering early load of NVMe modules..."
+-    modprobe apple-mailbox
+-    modprobe nvme-apple
++    # modprobe apple-mailbox
++    # modprobe nvme-apple
+     modprobe xhci-plat-hcd
+ 
+     for i in $(seq 0 50); do

--- a/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p15.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p15.ebuild
@@ -24,8 +24,7 @@ DESCRIPTION="Asahi Linux kernel sources"
 HOMEPAGE="https://asahilinux.org"
 KERNEL_URI="https://github.com/AsahiLinux/linux/archive/refs/tags/${MY_P}.tar.gz -> ${PN}-${PV}.tar.gz"
 SRC_URI="${KERNEL_URI}
-	https://raw.githubusercontent.com/AsahiLinux/PKGBUILDs/main/linux-asahi/config
-	https://raw.githubusercontent.com/AsahiLinux/PKGBUILDs/main/linux-asahi/config.edge
+	https://raw.githubusercontent.com/zzywysm/asahi-kernel-configs/ca3b0062e61099328b70b28f67783a1bb2cf1d1c/asahi-kernel-6.6-gentoo-comprehensive
 "
 
 S="${WORKDIR}/linux-${MY_P}"
@@ -56,10 +55,7 @@ PATCHES=(
 src_prepare() {
 	default
 	echo "-${MY_TAG}-dist" > localversion.10-pkgrel || die
-	cp "${DISTDIR}/config" ".config" || die
-	kernel-build_merge_configs "${DISTDIR}/config.edge"
-	echo 'CONFIG_LOCALVERSION=""' > "${T}/fakeversion.config"
-	kernel-build_merge_configs "${T}/fakeversion.config"
+	cp "${DISTDIR}/asahi-kernel-6.6-gentoo-comprehensive" ".config" || die
 }
 
 # Override kernel-install_pkg_preinst() to avoid ${PV}-as-release check


### PR DESCRIPTION
This pull request provides an Asahi Linux kernel configuration that matches the version of the code that this overlay ships.  It enables more of the Asahi Linux drivers than before, and should have comprehensive coverage of all peripherals it is possible to use with Apple Silicon at this point.

I anticipate delivering a larger configuration with all the PCI-based drivers enabled once Thunderbolt is supported by Asahi Linux.

These changes are completely untested as I do not have Gentoo installed on Apple Silicon.
