### PR TITLE
sys-kernel/asahi-kernel: install DTBs to correct location

### DIFF
--- a/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p15.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p15.ebuild
@@ -62,6 +62,12 @@ src_prepare() {
 	kernel-build_merge_configs "${T}/fakeversion.config"
 }
 
+src_install() {
+	# Override DTBs installation path for sys-apps/asahi-scripts::asahi
+	export INSTALL_DTBS_PATH="${ED}/usr/src/linux-${PV}${KV_LOCALVERSION}/arch/$(tc-arch-kernel)/boot/dts"
+	kernel-build_src_install
+}
+
 # Override kernel-install_pkg_preinst() to avoid ${PV}-as-release check
 pkg_preinst() {
 	true


### PR DESCRIPTION
Updates the install logic to install the DTBs to the location that
`asahi-scripts` expects, which fixes `update-m1n1` specifically.
