### PR TITLE
asahi-meta: fix deps for +mesa

### DIFF
--- a/metadata/md5-cache/sys-apps/asahi-meta-2-r5
+++ b/metadata/md5-cache/sys-apps/asahi-meta-2-r5
@@ -5,6 +5,6 @@ HOMEPAGE=https://asahilinux.org/
 IUSE=+audio +mesa
 KEYWORDS=arm64
 LICENSE=metapackage
-RDEPEND=sys-boot/m1n1 sys-boot/u-boot sys-apps/asahi-scripts sys-apps/asahi-configs sys-firmware/asahi-firmware sys-kernel/asahi-sources media-libs/alsa-ucm-conf-asahi audio? ( media-libs/asahi-audio ) mesa? ( >=media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(-)] )
+RDEPEND=sys-boot/m1n1 sys-boot/u-boot sys-apps/asahi-scripts sys-apps/asahi-configs sys-firmware/asahi-firmware sys-kernel/asahi-kernel media-libs/alsa-ucm-conf-asahi audio? ( media-libs/asahi-audio ) mesa? ( >=media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(-)] ) mesa? ( >=sys-kernel/asahi-kernel-6.6.0_p15 )
 SLOT=0
-_md5_=252cbec369492746e5fa2ddadd29ec9f
+_md5_=69c713c0399d290ba1bc7cda341f3ba3

--- a/metadata/md5-cache/sys-apps/asahi-meta-2-r5
+++ b/metadata/md5-cache/sys-apps/asahi-meta-2-r5
@@ -1,0 +1,10 @@
+DEFINED_PHASES=-
+DESCRIPTION=Metapackage for the Asahi support packages
+EAPI=8
+HOMEPAGE=https://asahilinux.org/
+IUSE=+audio +mesa
+KEYWORDS=arm64
+LICENSE=metapackage
+RDEPEND=sys-boot/m1n1 sys-boot/u-boot sys-apps/asahi-scripts sys-apps/asahi-configs sys-firmware/asahi-firmware sys-kernel/asahi-sources media-libs/alsa-ucm-conf-asahi audio? ( media-libs/asahi-audio ) mesa? ( >=media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(-)] )
+SLOT=0
+_md5_=252cbec369492746e5fa2ddadd29ec9f

--- a/sys-apps/asahi-meta/asahi-meta-2-r5.ebuild
+++ b/sys-apps/asahi-meta/asahi-meta-2-r5.ebuild
@@ -17,8 +17,9 @@ RDEPEND="
 	sys-apps/asahi-scripts
 	sys-apps/asahi-configs
 	sys-firmware/asahi-firmware
-	sys-kernel/asahi-sources
+	sys-kernel/asahi-kernel
 	media-libs/alsa-ucm-conf-asahi
 	audio? ( media-libs/asahi-audio )
 	mesa? ( >=media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(-)] )
+	mesa? ( >=sys-kernel/asahi-kernel-6.6.0_p15 )
 "

--- a/sys-apps/asahi-meta/asahi-meta-2-r5.ebuild
+++ b/sys-apps/asahi-meta/asahi-meta-2-r5.ebuild
@@ -20,5 +20,5 @@ RDEPEND="
 	sys-kernel/asahi-sources
 	media-libs/alsa-ucm-conf-asahi
 	audio? ( media-libs/asahi-audio )
-	mesa? ( =media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(+)] )
+	mesa? ( >=media-libs/mesa-24.1.0_pre20240228[video_cards_asahi(-)] )
 "


### PR DESCRIPTION
- require media-libs/mesa with ``video_cards_asahi` but be less strict about the version
- replace asahi-sources with asahi-kernel
- for `+mesa` also require a kernel with matching asahi GPU UAPI