### PR TITLE
sys-kernel/asahi-kernel: Add maximal rust version dep

### DIFF
--- a/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r1.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r1.ebuild
@@ -42,8 +42,10 @@ IUSE="debug"
 # Rust is non-negotiable for the dist kernel
 DEPEND="
 	${DEPEND}
-	|| ( >=dev-lang/rust-1.72.0[rust-src,rustfmt]
-		 >=dev-lang/rust-bin-1.72.0[rust-src,rustfmt]
+	|| ( dev-lang/rust:stable/1.74[rust-src,rustfmt]
+		 dev-lang/rust:stable/1.75[rust-src,rustfmt]
+		 ~dev-lang/rust-bin-1.74[rust-src,rustfmt]
+		 ~dev-lang/rust-bin-1.75[rust-src,rustfmt]
 	   )
 	dev-util/bindgen
 	debug? ( dev-util/pahole )


### PR DESCRIPTION
asahi-6.6-16 (patched) needs rust 1.74 or 1.75.