### PR TITLE
sys-apps/asahi-scripts: add missing deps to dracut's asahi-firmware module

### DIFF
--- a/sys-apps/asahi-scripts/asahi-scripts-20231219.1-r2.ebuild
+++ b/sys-apps/asahi-scripts/asahi-scripts-20231219.1-r2.ebuild
@@ -11,7 +11,9 @@ SLOT="0"
 KEYWORDS="arm64"
 
 PATCHES=("${FILESDIR}/makefile.patch"
-	 "${FILESDIR}/update-m1n1-dtbs.patch")
+	"${FILESDIR}/update-m1n1-dtbs.patch"
+	"${FILESDIR}/20231219.1_dracut_fw_grep_mkdir_deps.patch"
+	)
 
 BDEPEND="
 	dev-build/make"

--- a/sys-apps/asahi-scripts/files/20231219.1_dracut_fw_grep_mkdir_deps.patch
+++ b/sys-apps/asahi-scripts/files/20231219.1_dracut_fw_grep_mkdir_deps.patch
@@ -1,0 +1,25 @@
+From d6df77b2d68c1433af0fef15e5889c6f08c4d521 Mon Sep 17 00:00:00 2001
+From: Janne Grunau <j@jannau.net>
+Date: Mon, 1 Apr 2024 08:09:27 +0200
+Subject: [PATCH] dracut: Install grep, mkdir as functions.sh deps
+
+Missing grep in the initramfs was observed with dracut on gentoo.
+
+Signed-off-by: Janne Grunau <j@jannau.net>
+---
+ dracut/modules.d/99asahi-firmware/module-setup.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dracut/modules.d/99asahi-firmware/module-setup.sh b/dracut/modules.d/99asahi-firmware/module-setup.sh
+index 9018db5..db6ef99 100755
+--- a/dracut/modules.d/99asahi-firmware/module-setup.sh
++++ b/dracut/modules.d/99asahi-firmware/module-setup.sh
+@@ -30,7 +30,7 @@ install() {
+     asahiscriptsdir="/usr/share/asahi-scripts"
+     inst_dir $asahiscriptsdir
+     $DRACUT_CP -R -L -t "${initdir}/${asahiscriptsdir}" "${dracutsysrootdir}${asahiscriptsdir}"/*
+-    inst_multiple cpio cut dirname modprobe mount seq sleep umount
++    inst_multiple cpio cut dirname grep mkdir modprobe mount seq sleep umount
+     inst_hook pre-udev 10 "${moddir}/load-asahi-firmware.sh"
+     inst_hook cleanup 99 "${moddir}/install-asahi-firmware.sh"
+ }


### PR DESCRIPTION
Submitted as https://github.com/AsahiLinux/asahi-scripts/pull/43 Adds `grep` and `mkdir` as dependencies for the asahi-firmware module as those are used indirectly by asahi-scripts' functions.sh.