### PR TITLE
asahi-kernel symlink fixes for merged-usr

### DIFF
--- a/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r2.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r2.ebuild
@@ -73,8 +73,13 @@ src_prepare() {
 	# prepare the default config
 	cp "${DISTDIR}/kernel-aarch64-16k-fedora.config-${CONFIG_VER}" ".config" || die
 
-	# localversion.05-asahi already appends "-asahi"
-	local myversion="-${MY_TAG}-dist"
+	# ensure a consistant version across kernel and gentoo
+	# this passes the ${PV}-as-release check in kernel-install_pkg_preinst()
+	# override "-asahi" in localversion.05-asahi with "_pX" to override the
+	# kernel's base varsion to gentoo's ${PV}
+	echo "-p${MY_TAG}" > localversion.05-asahi
+	# use CONFIG_LOCALVERSION to provide "asahi" and "dist" annotations.
+	local myversion="-asahi-dist"
 	echo "CONFIG_LOCALVERSION=\"${myversion}\"" > "${T}"/version.config || die
 	local dist_conf_path="${WORKDIR}/gentoo-kernel-config-${GENTOO_CONFIG_VER}"
 
@@ -112,11 +117,6 @@ src_install() {
 	for dtb in /boot/dtbs/${module_ver}/apple/*.dtb; do
 		dosym ${dtb} /${kernel_dir}/arch/arm64/boot/dts/apple/$(basename ${dtb})
 	done
-}
-
-# Override kernel-install_pkg_preinst() to avoid ${PV}-as-release check
-pkg_preinst() {
-	true
 }
 
 pkg_postinst() {

--- a/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r2.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.6.0_p16-r2.ebuild
@@ -98,6 +98,22 @@ src_prepare() {
 	kernel-build_merge_configs "${merge_configs[@]}"
 }
 
+src_install() {
+	# call kernel-build's scr_install
+	kernel-build_src_install
+
+	# symlink installed *.dtbs back into kernel "source" directory
+	local dir_ver=${PV}${KV_LOCALVERSION}
+	local kernel_dir=/usr/src/linux-${dir_ver}
+	local relfile=${ED}${kernel_dir}/include/config/kernel.release
+	local module_ver
+	module_ver=$(<"${relfile}") || die
+
+	for dtb in /boot/dtbs/${module_ver}/apple/*.dtb; do
+		dosym ${dtb} /${kernel_dir}/arch/arm64/boot/dts/apple/$(basename ${dtb})
+	done
+}
+
 # Override kernel-install_pkg_preinst() to avoid ${PV}-as-release check
 pkg_preinst() {
 	true


### PR DESCRIPTION
This requires a change to the version to allow us to use `kernel-install_pkg_preinst()`.

Also provides symlinks to the installed "apple" dtbs in "/boot/dtbs/" which would allow reverting 0bb6aaae3001eb58