### PR TITLE
Install update-grub with sys-apps/asahi-scripts

### DIFF
--- a/sys-apps/asahi-scripts/asahi-scripts-20240429.ebuild
+++ b/sys-apps/asahi-scripts/asahi-scripts-20240429.ebuild
@@ -27,6 +27,8 @@ src_install() {
 	# install gentoo sys config
 	insinto /etc/default
 	newins "${FILESDIR}"/update-m1n1.gentoo.conf update-m1n1
+
+	dobin ${S}/update-grub
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Hey, there! I understand you might not want this change, and that's totally okay. Recently I busted the `BOOTAA64.EFI` binary on my M1 Pro, totally through user error. I recovered by using the `update-grub` script while `arch-chroot`ed in from a live USB, but I was surprised to see that it wasn't already part of the package. I see that upstream [only includes it for Arch binary distribution](https://github.com/AsahiLinux/asahi-scripts/blob/main/Makefile#L6). If I need to rebase for the sake of #89, let me know.

I'm super excited to see all of the stabilization work that's going on here, keep up the great work!