### PR TITLE
sys-apps/speakersafetyd: use cargo_src_install and emake install-data

### DIFF
--- a/sys-apps/speakersafetyd/speakersafetyd-1.0.0.ebuild
+++ b/sys-apps/speakersafetyd/speakersafetyd-1.0.0.ebuild
@@ -111,7 +111,8 @@ RDEPEND="${DEPEND}"
 QA_FLAGS_IGNORED="usr/bin/${PN}"
 
 src_install() {
-	emake DESTDIR="${D}" install || die
+	cargo_src_install
+	emake DESTDIR="${D}" install-data
 	doinitd "${FILESDIR}/speakersafetyd"
 }
 


### PR DESCRIPTION
```sh
>>> Install sys-apps/speakersafetyd-1.0.0 into /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image
make -j10 DESTDIR=/var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image install 
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//lib/systemd/system
install -pm0644 speakersafetyd.service /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//lib/systemd/system/speakersafetyd.service
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//lib/udev/rules.d
install -pm0644 95-speakersafetyd.rules /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//lib/udev/rules.d/95-speakersafetyd.rules
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/share//speakersafetyd/apple
install -pm0644 -t /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/share//speakersafetyd/apple conf/apple/j180.conf conf/apple/j274.conf conf/apple/j293.conf conf/apple/j313.conf conf/apple/j314.conf conf/apple/j316.conf conf/apple/j375.conf conf/apple/j413.conf conf/apple/j414.conf conf/apple/j415.conf conf/apple/j416.conf conf/apple/j456.conf conf/apple/j457.conf conf/apple/j473.conf conf/apple/j474.conf conf/apple/j475.conf conf/apple/j493.conf
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//var//lib/speakersafetyd/blackbox
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/lib/tmpfiles.d
install -pm0644 speakersafetyd.tmpfiles /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/lib/tmpfiles.d/speakersafetyd.conf
install -dDm0755 /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/bin
install -pm0755 target/release/speakersafetyd /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/bin/speakersafetyd
/usr/bin/install: cannot stat 'target/release/speakersafetyd': No such file or directory
install-xattr: failed to stat /var/tmp/portage/sys-apps/speakersafetyd-1.0.0/image//usr/bin/speakersafetyd: No such file or directory
make: *** [Makefile:16: install] Error 1
```

Thx to parona, I've stumbled across https://bugs.gentoo.org/937782 and saw Gentoo builds target specific releases now.
But there is [`cargo_src_install`](https://devmanual.gentoo.org/eclass-reference/cargo.eclass/index.html).