### PR TITLE
sys-apps/speakersafetyd: fix udev post hooks

### DIFF
--- a/sys-apps/speakersafetyd/speakersafetyd-1.0.0.ebuild
+++ b/sys-apps/speakersafetyd/speakersafetyd-1.0.0.ebuild
@@ -116,7 +116,12 @@ src_install() {
 	doinitd "${FILESDIR}/speakersafetyd"
 }
 
-src_postinst() {
+pkg_postinst() {
+	udev_reload
+	default
+}
+ 
+pkg_postrm() {
 	udev_reload
 	default
 }


### PR DESCRIPTION
According to the [docs](https://devmanual.gentoo.org/ebuild-writing/functions/index.html) we have to make use of [`pkg_postinst`](https://devmanual.gentoo.org/ebuild-writing/functions/pkg_postinst/index.html) and [`pkg_postrm`](https://devmanual.gentoo.org/ebuild-writing/functions/pkg_postrm/index.html). 

Depends on https://github.com/chadmed/asahi-overlay/pull/103