### PR TITLE
gui-wm/sommelier: Add alignment patch.

### DIFF
--- a/gui-wm/sommelier/files/sommelier-0.12-enforce-16k-alignment.patch
+++ b/gui-wm/sommelier/files/sommelier-0.12-enforce-16k-alignment.patch
@@ -1,0 +1,58 @@
+Upstream: no
+
+From 10056fbb3f09d448a00748fea48dc6c630948d90 Mon Sep 17 00:00:00 2001
+From: Johannes Nixdorf <johannes@nixdorf.dev>
+Date: Wed, 29 May 2024 21:20:53 +0200
+Subject: [PATCH] Import the 16k alignment patch hidden in the copr sources
+
+---
+ sommelier-seat.cc                 | 4 +++-
+ virtualization/virtgpu_channel.cc | 4 +++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/sommelier-seat.cc b/sommelier-seat.cc
+index 3a056ca00ea8..c8dc85fcacb1 100644
+--- a/sommelier-seat.cc
++++ b/sommelier-seat.cc
+@@ -286,6 +286,8 @@ static void sl_host_keyboard_release(struct wl_client* client,
+ static const struct wl_keyboard_interface sl_keyboard_implementation = {
+     sl_host_keyboard_release};
+ 
++#define ALIGN_POT(x, pot_align) (((x) + (pot_align) - 1) & ~((pot_align) - 1))
++
+ static void sl_keyboard_keymap(void* data,
+                                struct wl_keyboard* keyboard,
+                                uint32_t format,
+@@ -297,7 +299,7 @@ static void sl_keyboard_keymap(void* data,
+   wl_keyboard_send_keymap(host->resource, format, fd, size);
+ 
+   if (format == WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
+-    void* data = mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, 0);
++    void* data = mmap(nullptr, ALIGN_POT(size, 16384), PROT_READ, MAP_SHARED, fd, 0);
+ 
+     assert(data != MAP_FAILED);
+ 
+diff --git a/virtualization/virtgpu_channel.cc b/virtualization/virtgpu_channel.cc
+index ff4c07cffbf4..fcfbb8c7707c 100644
+--- a/virtualization/virtgpu_channel.cc
++++ b/virtualization/virtgpu_channel.cc
+@@ -617,13 +617,15 @@ int32_t VirtGpuChannel::channel_poll() {
+   return 0;
+ }
+ 
++#define ALIGN_POT(x, pot_align) (((x) + (pot_align) - 1) & ~((pot_align) - 1))
++
+ int32_t VirtGpuChannel::create_host_blob(uint64_t blob_id,
+                                          uint64_t size,
+                                          int& out_fd) {
+   int32_t ret;
+   struct drm_virtgpu_resource_create_blob drm_rc_blob = {};
+ 
+-  drm_rc_blob.size = size;
++  drm_rc_blob.size = ALIGN_POT(size, 16384);
+   drm_rc_blob.blob_mem = VIRTGPU_BLOB_MEM_HOST3D;
+   drm_rc_blob.blob_flags =
+       VIRTGPU_BLOB_FLAG_USE_MAPPABLE | VIRTGPU_BLOB_FLAG_USE_SHAREABLE;
+-- 
+2.45.1
+

--- a/gui-wm/sommelier/sommelier-0.12_p20240820-r1.ebuild
+++ b/gui-wm/sommelier/sommelier-0.12_p20240820-r1.ebuild
@@ -20,6 +20,7 @@ KEYWORDS="~amd64 ~arm64"
 
 PATCHES="
 	${FILESDIR}/${PN}-0.12-disable-vgpu-stride-fix.patch
+	${FILESDIR}/${PN}-0.12-enforce-16k-alignment.patch
 "
 
 IUSE="test"


### PR DESCRIPTION
Not sure as to what exactly it fixes, but fedora has it, and it should not hurt anything.