### PR TITLE
sys-kernel/asahi-kernel: Fix DTB file location in stable ebuild

### DIFF
--- a/sys-kernel/asahi-kernel/asahi-kernel-6.12.1_p8.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.12.1_p8.ebuild
@@ -130,9 +130,9 @@ src_install() {
 	kernel-build_src_install
 
 	# symlink installed *.dtbs back into kernel "source" directory
-	for dtb in ${ED}/boot/dtbs/${KV_FULL}/apple/*.dtb; do
+	for dtb in "${ED}/lib/modules/${KV_FULL}/dtb/apple/"*.dtb; do
 		local basedtb=$(basename ${dtb})
-		dosym -r ${EROOT}/boot/dtbs/${KV_FULL}/apple/${basedtb} ${EROOT}/usr/src/linux-${KV_FULL}/arch/arm64/boot/dts/apple/${basedtb}
+		dosym -r "${dtb##${ED}}" "/usr/src/linux-${KV_FULL}/arch/arm64/boot/dts/apple/${basedtb}"
 	done
 }
 


### PR DESCRIPTION
The stable ebuild for asahi-kernel (6.12.1_p8) does not account for the updated DTB file location. This leads to broken symlinks and missing DTB in the expected paths. I took the code from asahi-kernel-6.12.4_p1-r1.ebuild to update asahi-kernel-6.12.1_p8.ebuild

Fixes: chadmed/asahi-gentoosupport#30