### PR TITLE
sys-kernel/asahi-kernel: Use RUST_REQ_USE

### DIFF
--- a/sys-kernel/asahi-kernel/asahi-kernel-6.12.4_p1-r1.ebuild
+++ b/sys-kernel/asahi-kernel/asahi-kernel-6.12.4_p1-r1.ebuild
@@ -7,7 +7,7 @@ ETYPE="sources"
 K_NODRYRUN="1"
 
 RUST_MIN_VER="1.76.0"
-RUST_USEDEP='rust-src,rustfmt'
+RUST_REQ_USE='rust-src,rustfmt'
 
 inherit kernel-build rust
 


### PR DESCRIPTION
This solves the [breaking change](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=9224c0acf8aa541c49de424042c88e87f0e76e26) introduced in the `rust` eclass, which replaces `RUST_USEDEP` with `RUST_REQ_USE`. I replaced  `RUST_USEDEP` with `RUST_REQ_USE` in asahi-kernel ebuild.

Closes: #143 