### PR TITLE
gui-wm/sommelier: Rename to jinja2 in check_deps as well

### DIFF
--- a/gui-wm/sommelier/sommelier-0.12_p20241015.ebuild
+++ b/gui-wm/sommelier/sommelier-0.12_p20241015.ebuild
@@ -54,7 +54,7 @@ RDEPEND="
 "
 
 python_check_deps() {
-	python_has_version "dev-python/jinja[${PYTHON_USEDEP}]"
+	python_has_version "dev-python/jinja2[${PYTHON_USEDEP}]"
 }
 
 src_configure() {


### PR DESCRIPTION
This fixes [dcd4c9b](https://github.com/chadmed/asahi-overlay/commit/dcd4c9b1010d525b0d6e90a0d3b407096572ad69)

The rename wasnt complete and when emerging no python version could not be found because the package didnt exist

