### PR TITLE
app-emulation/FEX: Enable +fexconfig by default

### DIFF
--- a/app-emulation/FEX/FEX-2508.1.ebuild
+++ b/app-emulation/FEX/FEX-2508.1.ebuild
@@ -77,7 +77,7 @@ PATCHES="
 	${FILESDIR}/${PN}-2503-thunkgen-gcc-install-dir.patch
 "
 
-IUSE="crossdev-toolchain fexconfig qt6 +thunks"
+IUSE="crossdev-toolchain +fexconfig +qt6 +thunks"
 
 REQUIRED_USE="
 	crossdev-toolchain? ( thunks )


### PR DESCRIPTION
I find it rather unlikely that someone is going to run FEX+headless, and FEXConfig is needed to set up the default RootFS location