### PR TITLE
app-emulation/FEX: Bump linux-headers dependency to >=6.17

### DIFF
--- a/app-emulation/FEX/FEX-2511.ebuild
+++ b/app-emulation/FEX/FEX-2511.ebuild
@@ -66,7 +66,7 @@ RDEPEND="
 "
 DEPEND="
 	dev-cpp/range-v3
-	>=sys-kernel/linux-headers-6.14
+	>=sys-kernel/linux-headers-6.17
 	${RDEPEND}
 "
 


### PR DESCRIPTION
Required for DRM_IOCTL_MSM_VM_BIND and
DRM_IOCTL_PANTHOR_SET_USER_MMIO_OFFSET.