### PR TITLE
sys-apps/asahi-meta: add missing KDE USE flag description

### DIFF
--- a/sys-apps/asahi-meta/metadata.xml
+++ b/sys-apps/asahi-meta/metadata.xml
@@ -7,6 +7,7 @@
     </maintainer>
     <use>
         <flag name="mesa">Pull in <pkg>media-libs/mesa</pkg> with VIDEO_CARDS="asahi"</flag>
+        <flag name="kde">Pull in <pkg>kde-plasma/kwin</pkg> with filecaps support</flag>
         <flag name="sound">Pull in <pkg>media-libs/asahi-audio</pkg> and its dependencies</flag>
     </use>
     <upstream>


### PR DESCRIPTION
The kde USE flag is defined in IUSE but was missing a description in metadata.xml.

Signed-off-by: Aarav Desai <areofyl@users.noreply.github.com>